### PR TITLE
Restrict Python version & update classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "stackstac",
         "termcolor",
     ],
-    python_requires=">=3.8, <4.0",
+    python_requires=">=3.8",
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "License :: OSI Approved :: MIT License",

--- a/setup.py
+++ b/setup.py
@@ -31,10 +31,10 @@ setup(
         "stackstac",
         "termcolor",
     ],
+    python_requires=">=3.8, <4.0",
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
     ],


### PR DESCRIPTION
Uses `python_requires` in `setup.py` to restrict installation to only Python>=3.8 environments. Also updates the trove classifiers to represent the supported Python versions.

Closes #1